### PR TITLE
Switch `bzip2` crate to `bzip2-rs` to fix a build failure when used for WebAssembly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bzip2 = "0.4"
+bzip2-rs = "0.1"
 flate2 = "1"
 
 [workspace]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -3,7 +3,6 @@ use std::{
     io::{BufRead, Read, Seek, SeekFrom},
 };
 
-use bzip2::read::BzDecoder;
 use flate2::read::GzDecoder;
 pub use options::DataReaderOptions;
 
@@ -151,7 +150,7 @@ where
                 decoded
             }
             Some(b"bzip2") => {
-                let mut reader = BzDecoder::new(&buf[..]);
+                let mut reader = bzip2_rs::DecoderReader::new(&buf[..]);
                 let mut decoded = Vec::new();
                 reader.read_to_end(&mut decoded).map_err(|e| {
                     Error::from_string(format!("reading bzip2-compressed body failed: {e}"))
@@ -452,7 +451,7 @@ format=field:{{10}}UINT8
             false,
             "compress_type=bzip2\n",
             Err(crate::Error::from_str(
-                "reading bzip2-compressed body failed: decompression not finished but EOF reached"
+                "reading bzip2-compressed body failed: whole stream crc truncated"
             ))
         ),
         (
@@ -496,7 +495,7 @@ format=field:{{10}}UINT8
             false,
             "compress_type=bzip2\n",
             Err(crate::Error::from_str(
-                "reading bzip2-compressed body failed: bzip2: bz2 header missing"
+                "reading bzip2-compressed body failed: invalid file signature"
             ))
         ),
         (


### PR DESCRIPTION
This PR switches dependency on `bzip2` crate to `bzip2-rs` to fix a build failure when used for WebAssembly.

Build for WebAssembly has failed due to an error like this:

```
The following warnings were emitted during compilation:

warning: In file included from bzip2-1.0.8/blocksort.c:22:
warning: bzip2-1.0.8/bzlib_private.h:25:10: fatal error: 'stdlib.h' file not found
warning: #include <stdlib.h>
warning:          ^~~~~~~~~~
warning: 1 error generated.

error: failed to run custom build command for `bzip2-sys v0.1.11+1.0.8`

Caused by:
  process didn't exit successfully: `/Users/noritada/gitwc/private/rrr-rs/target/debug/build/bzip2-sys-62546e21fa4e59e1/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=BZIP2_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_CROSS_wasm32-unknown-unknown
  cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_CROSS_wasm32_unknown_unknown
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG_ALLOW_CROSS
  cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_CROSS
  cargo:rerun-if-env-changed=PKG_CONFIG_wasm32-unknown-unknown
  cargo:rerun-if-env-changed=PKG_CONFIG_wasm32_unknown_unknown
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_wasm32-unknown-unknown
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_wasm32_unknown_unknown
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  TARGET = Some("wasm32-unknown-unknown")
  OPT_LEVEL = Some("0")
  HOST = Some("x86_64-apple-darwin")
  CC_wasm32-unknown-unknown = None
  CC_wasm32_unknown_unknown = None
  TARGET_CC = None
  CC = None
  CFLAGS_wasm32-unknown-unknown = None
  CFLAGS_wasm32_unknown_unknown = None
  TARGET_CFLAGS = None
  CFLAGS = None
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("true")
  running: "clang" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "--target=wasm32-unknown-unknown" "-I" "bzip2-1.0.8" "-D_FILE_OFFSET_BITS=64" "-DBZ_NO_STDIO" "-o" "/Users/noritada/gitwc/private/rrr-rs/target/wasm32-unknown-unknown/debug/build/bzip2-sys-1195f58ad7bc07c5/out/lib/bzip2-1.0.8/blocksort.o" "-c" "bzip2-1.0.8/blocksort.c"
  cargo:warning=In file included from bzip2-1.0.8/blocksort.c:22:
  cargo:warning=bzip2-1.0.8/bzlib_private.h:25:10: fatal error: 'stdlib.h' file not found
  cargo:warning=#include <stdlib.h>
  cargo:warning=         ^~~~~~~~~~
  cargo:warning=1 error generated.
  exit status: 1

  --- stderr


  error occurred: Command "clang" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "--target=wasm32-unknown-unknown" "-I" "bzip2-1.0.8" "-D_FILE_OFFSET_BITS=64" "-DBZ_NO_STDIO" "-o" "/Users/noritada/gitwc/private/rrr-rs/target/wasm32-unknown-unknown/debug/build/bzip2-sys-1195f58ad7bc07c5/out/lib/bzip2-1.0.8/blocksort.o" "-c" "bzip2-1.0.8/blocksort.c" with args "clang" did not execute successfully (status code exit status: 1).
```
