### PR TITLE
JSON output pretty-printing

### DIFF
--- a/cli/src/command/dump.rs
+++ b/cli/src/command/dump.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::{arg, ArgAction, ArgMatches, Command};
-use rrr::{DataReaderOptions, JsonDisplay};
+use rrr::{DataReaderOptions, JsonDisplay, JsonDisplayRule};
 
 use crate::common::read_from_source;
 
@@ -11,6 +11,7 @@ pub(crate) fn cli() -> Command {
             arg!(--"ignore-size" r#"Ignore the value of "data_size" field in reading"#)
                 .action(ArgAction::SetTrue),
         )
+        .arg(arg!(--pretty r#"Pretty-print the JSON output"#).action(ArgAction::SetTrue))
         .arg(arg!(<PATH_OR_URI> "Path or S3 URI of the file").required(true))
 }
 
@@ -22,9 +23,14 @@ pub(crate) async fn exec(args: &ArgMatches) -> Result<()> {
     } else {
         options
     };
+    let rule = if args.get_flag("pretty") {
+        JsonDisplayRule::Pretty
+    } else {
+        JsonDisplayRule::Minimal
+    };
     let (schema, _, body_buf) = read_from_source(fname, None, options).await?;
 
-    println!("{}", JsonDisplay::new(&schema, &body_buf));
+    println!("{}", JsonDisplay::new(&schema, &body_buf, rule));
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub use crate::{
     ast::{Ast, AstKind, Len, Location, Schema, SchemaParseError, SchemaParseErrorKind},
     reader::{DataReader, DataReaderOptions},
     utils::json_escape_str,
-    visitor::{AstVisitor, JsonDisplay, SchemaOnelineDisplay},
+    visitor::{AstVisitor, JsonDisplay, JsonDisplayRule, SchemaOnelineDisplay},
 };
 
 fn visit<'f, F, G>(node: &'f Ast, start_f: &mut F, end_f: &mut G) -> Result<(), Error>


### PR DESCRIPTION
This PR adds a feature to pretty-print the JSON output by inserting separator/indent spaces and newlines.