### PR TITLE
Use `BTreeMap` instead of `HashMap` to fix the order of header fields

### DIFF
--- a/cli/src/command/header.rs
+++ b/cli/src/command/header.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt};
+use std::{collections::BTreeMap, fmt};
 
 use anyhow::Result;
 use clap::{arg, ArgMatches, Command};
@@ -28,7 +28,7 @@ pub(crate) async fn exec(args: &ArgMatches) -> Result<()> {
     Ok(())
 }
 
-struct HeaderDisplay<'a>(&'a HashMap<Vec<u8>, Vec<u8>>);
+struct HeaderDisplay<'a>(&'a BTreeMap<Vec<u8>, Vec<u8>>);
 
 impl<'a> fmt::Display for HeaderDisplay<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     io::{BufRead, Seek},
 };
 
@@ -12,7 +12,7 @@ pub(crate) async fn read_from_source(
     source: &str,
     n_bytes: Option<&usize>,
     options: DataReaderOptions,
-) -> Result<(Schema, HashMap<Vec<u8>, Vec<u8>>, Vec<u8>)> {
+) -> Result<(Schema, BTreeMap<Vec<u8>, Vec<u8>>, Vec<u8>)> {
     if source[0..5] == "s3://"[..] {
         read_from_s3(source, n_bytes, options).await
     } else {
@@ -24,7 +24,7 @@ async fn read_from_s3(
     url: &str,
     n_bytes: Option<&usize>,
     options: DataReaderOptions,
-) -> Result<(Schema, HashMap<Vec<u8>, Vec<u8>>, Vec<u8>)> {
+) -> Result<(Schema, BTreeMap<Vec<u8>, Vec<u8>>, Vec<u8>)> {
     let url = url::Url::parse(url)?;
 
     let bucket_name = if let Some(url::Host::Domain(s)) = url.host() {
@@ -67,7 +67,7 @@ async fn download_s3_object(
 fn read_from_file(
     fname: &str,
     options: DataReaderOptions,
-) -> Result<(Schema, HashMap<Vec<u8>, Vec<u8>>, Vec<u8>)> {
+) -> Result<(Schema, BTreeMap<Vec<u8>, Vec<u8>>, Vec<u8>)> {
     let input_path = std::path::PathBuf::from(fname);
     let f = std::fs::File::open(input_path)?;
     let f = std::io::BufReader::new(f);
@@ -77,7 +77,7 @@ fn read_from_file(
 fn read_from_reader<R>(
     reader: R,
     options: DataReaderOptions,
-) -> Result<(Schema, HashMap<Vec<u8>, Vec<u8>>, Vec<u8>)>
+) -> Result<(Schema, BTreeMap<Vec<u8>, Vec<u8>>, Vec<u8>)>
 where
     R: BufRead + Seek,
 {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     io::{BufRead, Read, Seek, SeekFrom},
 };
 
@@ -30,7 +30,7 @@ impl<R> DataReader<R>
 where
     R: BufRead + Seek,
 {
-    pub fn read(&mut self) -> Result<(Schema, HashMap<Vec<u8>, Vec<u8>>, Vec<u8>), Error> {
+    pub fn read(&mut self) -> Result<(Schema, BTreeMap<Vec<u8>, Vec<u8>>, Vec<u8>), Error> {
         self.inner.rewind()?;
         self.find_magic()?;
         let map = self.read_header_fields()?;
@@ -73,7 +73,7 @@ where
 
     fn read_header_fields(&mut self) -> Result<FieldMap, Error> {
         let mut sep_buf = vec![0; Self::SEP_MAGIC_LEN];
-        let mut map = HashMap::new();
+        let mut map = BTreeMap::new();
 
         loop {
             self.inner
@@ -168,10 +168,10 @@ where
     }
 }
 
-struct FieldMap(HashMap<Vec<u8>, Vec<u8>>);
+struct FieldMap(BTreeMap<Vec<u8>, Vec<u8>>);
 
 impl FieldMap {
-    fn inner(self) -> HashMap<Vec<u8>, Vec<u8>> {
+    fn inner(self) -> BTreeMap<Vec<u8>, Vec<u8>> {
         let Self(inner) = self;
         inner
     }

--- a/web/src/header.rs
+++ b/web/src/header.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use yew::prelude::*;
 
-pub(crate) fn create_header_view(map: &HashMap<Vec<u8>, Vec<u8>>) -> Html {
+pub(crate) fn create_header_view(map: &BTreeMap<Vec<u8>, Vec<u8>>) -> Html {
     map.iter()
         .map(|(key, value)| create_header_field(key, value))
         .collect::<Html>()
@@ -23,7 +23,7 @@ mod tests {
 
     #[test]
     fn header_view_creation() {
-        let mut map = HashMap::new();
+        let mut map = BTreeMap::new();
         map.insert(b"key1".to_vec(), b"value1".to_vec());
         map.insert(b"key2".to_vec(), b"value2".to_vec());
         let actual = create_header_view(&map);


### PR DESCRIPTION
This PR fixes test failures due to unordered header fields by changing the data structure of header fields.
This breaks backward compatibility of the API.