### PR TITLE
Update dependencies on AWS SDK for Rust

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 aws-config = "0.56"
-aws-sdk-s3 = "0.31"
+aws-sdk-s3 = "0.33"
 bytes = "1"
 clap = "4"
 clap_complete = "4"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,8 +9,8 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-aws-config = "0.56"
-aws-sdk-s3 = "0.34"
+aws-config = "0.57"
+aws-sdk-s3 = "0.35"
 bytes = "1"
 clap = "4"
 clap_complete = "4"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,8 +9,8 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-aws-config = "0.57"
-aws-sdk-s3 = "0.36"
+aws-config = "0.100"
+aws-sdk-s3 = "0.37"
 bytes = "1"
 clap = "4"
 clap_complete = "4"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,8 +9,8 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-aws-config = "0.100"
-aws-sdk-s3 = "0.37"
+aws-config = "1"
+aws-sdk-s3 = "1"
 bytes = "1"
 clap = "4"
 clap_complete = "4"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,8 +9,8 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-aws-config = "0.55"
-aws-sdk-s3 = "0.27"
+aws-config = "0.56"
+aws-sdk-s3 = "0.31"
 bytes = "1"
 clap = "4"
 clap_complete = "4"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 aws-config = "0.56"
-aws-sdk-s3 = "0.33"
+aws-sdk-s3 = "0.34"
 bytes = "1"
 clap = "4"
 clap_complete = "4"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 aws-config = "0.57"
-aws-sdk-s3 = "0.35"
+aws-sdk-s3 = "0.36"
 bytes = "1"
 clap = "4"
 clap_complete = "4"

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -45,7 +45,7 @@ async fn download_s3_object(
     key: &str,
     n_bytes: Option<&usize>,
 ) -> Result<bytes::Bytes> {
-    let config = aws_config::load_from_env().await;
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::v2023_11_09()).await;
     let client = aws_sdk_s3::Client::new(&config);
 
     let req = client.get_object().bucket(bucket_name).key(key);

--- a/cli/src/diagnostics.rs
+++ b/cli/src/diagnostics.rs
@@ -79,7 +79,6 @@ pub(crate) fn create_s3_download_error_report(err: SdkError<GetObjectError>) -> 
         e => match e.into_service_error() {
             GetObjectError::InvalidObjectState(value) => format!("invalid object state: {value}"),
             GetObjectError::NoSuchKey(_) => "object does not exist".to_owned(),
-            GetObjectError::Unhandled(err) => format!("some unhandled error: {err}"),
             err @ _ => format!("error returned from S3: {err}"),
         },
     };


### PR DESCRIPTION
This PR updates dependencies on AWS SDK for Rust, which has been announced to be generally available.

See https://aws.amazon.com/about-aws/whats-new/2023/11/aws-sdk-rust/ for the announcement on 2023-11-27.