### PR TITLE
Support for some format variants

### DIFF
--- a/cli/src/command/dump.rs
+++ b/cli/src/command/dump.rs
@@ -17,7 +17,10 @@ pub(crate) fn cli() -> Command {
 
 pub(crate) async fn exec(args: &ArgMatches) -> Result<()> {
     let fname = args.get_one::<String>("PATH_OR_URI").unwrap();
-    let options = DataReaderOptions::ENABLE_READING_BODY;
+    let options = DataReaderOptions::ALLOW_TRAILING_COMMA
+        | DataReaderOptions::ALLOW_EMPTY_FIELD_NAME
+        | DataReaderOptions::ALLOW_STR_INSTEAD_OF_NSTR
+        | DataReaderOptions::ENABLE_READING_BODY;
     let options = if args.get_flag("ignore-size") {
         options.union(DataReaderOptions::IGNORE_DATA_SIZE_FIELD)
     } else {

--- a/cli/src/command/header.rs
+++ b/cli/src/command/header.rs
@@ -20,7 +20,9 @@ pub(crate) fn cli() -> Command {
 pub(crate) async fn exec(args: &ArgMatches) -> Result<()> {
     let fname = args.get_one::<String>("PATH_OR_URI").unwrap();
     let n_bytes = args.get_one::<usize>("N").unwrap();
-    let options = DataReaderOptions::default();
+    let options = DataReaderOptions::ALLOW_TRAILING_COMMA
+        | DataReaderOptions::ALLOW_EMPTY_FIELD_NAME
+        | DataReaderOptions::ALLOW_STR_INSTEAD_OF_NSTR;
     let (_, header, _) = read_from_source(fname, Some(n_bytes), options).await?;
 
     println!("{}", HeaderDisplay(&header));

--- a/cli/src/command/schema.rs
+++ b/cli/src/command/schema.rs
@@ -23,7 +23,9 @@ pub(crate) fn cli() -> Command {
 pub(crate) async fn exec(args: &ArgMatches) -> Result<()> {
     let fname = args.get_one::<String>("PATH_OR_URI").unwrap();
     let n_bytes = args.get_one::<usize>("N").unwrap();
-    let options = DataReaderOptions::default();
+    let options = DataReaderOptions::ALLOW_TRAILING_COMMA
+        | DataReaderOptions::ALLOW_EMPTY_FIELD_NAME
+        | DataReaderOptions::ALLOW_STR_INSTEAD_OF_NSTR;
     let (schema, _, _) = read_from_source(fname, Some(n_bytes), options).await?;
 
     if args.get_flag("tree") {

--- a/cli/src/visitor.rs
+++ b/cli/src/visitor.rs
@@ -196,7 +196,7 @@ fn prettify_special_field_name(name: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use rrr::Schema;
+    use rrr::{DataReaderOptions, Schema};
 
     use super::*;
 
@@ -205,7 +205,8 @@ mod tests {
             #[test]
             fn $name() {
                 let input = $input;
-                let schema = input.parse::<Schema>().unwrap();
+                let options = DataReaderOptions::default();
+                let schema = Schema::try_from((input.as_bytes(), options)).unwrap();
                 let actual = format!("{}", SchemaTreeDisplay(&schema.ast));
                 let actual = console::strip_ansi_codes(&actual);
                 let expected = $expected;

--- a/cli/src/visitor.rs
+++ b/cli/src/visitor.rs
@@ -196,7 +196,7 @@ fn prettify_special_field_name(name: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use rrr::{DataReaderOptions, Schema};
+    use rrr::{parse, DataReaderOptions};
 
     use super::*;
 
@@ -206,7 +206,7 @@ mod tests {
             fn $name() {
                 let input = $input;
                 let options = DataReaderOptions::default();
-                let schema = Schema::try_from((input.as_bytes(), options)).unwrap();
+                let schema = parse(input.as_bytes(), options).unwrap();
                 let actual = format!("{}", SchemaTreeDisplay(&schema.ast));
                 let actual = console::strip_ansi_codes(&actual);
                 let expected = $expected;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,21 +1,16 @@
 use crate::{param::ParamStack, DataReaderOptions};
 
+pub fn parse(bytes: &[u8], options: DataReaderOptions) -> Result<Schema, crate::Error> {
+    let parser = SchemaParser::new(bytes, options);
+    parser
+        .parse()
+        .map_err(|e| crate::Error::Schema(e, bytes.to_vec()))
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct Schema {
     pub ast: Ast,
     pub params: ParamStack,
-}
-
-impl TryFrom<(&[u8], DataReaderOptions)> for Schema {
-    type Error = crate::Error;
-
-    fn try_from(value: (&[u8], DataReaderOptions)) -> Result<Self, Self::Error> {
-        let (bytes, options) = value;
-        let parser = SchemaParser::new(bytes, options);
-        parser
-            .parse()
-            .map_err(|e| crate::Error::Schema(e, bytes.to_vec()))
-    }
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -233,7 +233,12 @@ impl<'b> SchemaParser<'b> {
         self.consume_symbol(TokenKind::RAngleBracket)?;
 
         if let TokenKind::Ident(s) = self.next_token()?.kind {
-            if s.as_str() != "NSTR" {
+            if !(s.as_str() == "NSTR"
+                || (self
+                    .options
+                    .contains(DataReaderOptions::ALLOW_STR_INSTEAD_OF_NSTR)
+                    && s.as_str() == "STR"))
+            {
                 return Err(self.err_unexpected_token());
             }
         } else {
@@ -791,6 +796,18 @@ mod tests {
             ":UINT8,",
             DataReaderOptions::ALLOW_TRAILING_COMMA | DataReaderOptions::ALLOW_EMPTY_FIELD_NAME,
             false
+        ),
+        (
+            str_instead_of_nstr_not_allowed,
+            "fld1:<4>NSTR,fld2:<4>STR",
+            DataReaderOptions::default(),
+            false
+        ),
+        (
+            str_instead_of_nstr_allowed,
+            "fld1:<4>NSTR,fld2:<4>STR",
+            DataReaderOptions::ALLOW_STR_INSTEAD_OF_NSTR,
+            true
         ),
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,15 +106,17 @@ mod tests {
     };
 
     fn schema_without_str() -> Result<Schema, Error> {
+        let options = DataReaderOptions::default();
         let ast = "date:[year:UINT16,month:UINT8,day:UINT8],\
             data:{4}[loc:<4>NSTR,temp:INT16,rhum:UINT16],comment:<16>NSTR";
-        ast.parse()
+        Schema::try_from((ast.as_bytes(), options))
     }
 
     fn schema_with_str() -> Result<Schema, Error> {
+        let options = DataReaderOptions::default();
         let ast = "date:[year:UINT16,month:UINT8,day:UINT8],\
             data:{4}[loc:STR,temp:INT16,rhum:UINT16],comment:<16>NSTR";
-        ast.parse()
+        Schema::try_from((ast.as_bytes(), options))
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod walker;
 use std::borrow::Cow;
 
 pub use crate::{
-    ast::{Ast, AstKind, Len, Location, Schema, SchemaParseError, SchemaParseErrorKind},
+    ast::{parse, Ast, AstKind, Len, Location, Schema, SchemaParseError, SchemaParseErrorKind},
     reader::{DataReader, DataReaderOptions},
     utils::json_escape_str,
     visitor::{AstVisitor, JsonDisplay, JsonFormattingStyle, SchemaOnelineDisplay},
@@ -100,7 +100,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        ast::{Schema, Size},
+        ast::{parse, Schema, Size},
         value::{Number, Value, ValueTree},
         walker::BufWalker,
     };
@@ -109,14 +109,14 @@ mod tests {
         let options = DataReaderOptions::default();
         let ast = "date:[year:UINT16,month:UINT8,day:UINT8],\
             data:{4}[loc:<4>NSTR,temp:INT16,rhum:UINT16],comment:<16>NSTR";
-        Schema::try_from((ast.as_bytes(), options))
+        parse(ast.as_bytes(), options)
     }
 
     fn schema_with_str() -> Result<Schema, Error> {
         let options = DataReaderOptions::default();
         let ast = "date:[year:UINT16,month:UINT8,day:UINT8],\
             data:{4}[loc:STR,temp:INT16,rhum:UINT16],comment:<16>NSTR";
-        Schema::try_from((ast.as_bytes(), options))
+        parse(ast.as_bytes(), options)
     }
 
     #[test]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -6,7 +6,10 @@ use std::{
 use flate2::read::GzDecoder;
 pub use options::DataReaderOptions;
 
-use crate::{ast::Schema, Error};
+use crate::{
+    ast::{parse, Schema},
+    Error,
+};
 
 mod options;
 
@@ -36,7 +39,7 @@ where
         let map = self.read_header_fields()?;
 
         let schema = map.get_required_field("format")?;
-        let schema: Schema = (schema.as_slice(), self.options).try_into()?;
+        let schema = parse(schema.as_slice(), self.options)?;
 
         let body = if self
             .options

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -36,7 +36,7 @@ where
         let map = self.read_header_fields()?;
 
         let schema = map.get_required_field("format")?;
-        let schema: Schema = schema.as_slice().try_into()?;
+        let schema: Schema = (schema.as_slice(), self.options).try_into()?;
 
         let body = if self
             .options

--- a/src/reader/options.rs
+++ b/src/reader/options.rs
@@ -10,6 +10,9 @@ impl DataReaderOptions {
     pub const IGNORE_DATA_SIZE_FIELD: Self = Self(1 << 2);
     /// Flag to allow a trailing comma in the `format` header field.
     pub const ALLOW_TRAILING_COMMA: Self = Self(1 << 3);
+    /// Flag to allow an empty string to be used for a field name when there are
+    /// no other fields.
+    pub const ALLOW_EMPTY_FIELD_NAME: Self = Self(1 << 4);
 
     /// Returns the union of `self` and a `flag`.
     pub fn union(&self, flag: Self) -> Self {

--- a/src/reader/options.rs
+++ b/src/reader/options.rs
@@ -24,6 +24,15 @@ impl DataReaderOptions {
     }
 }
 
+impl std::ops::BitOr for DataReaderOptions {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        let inner = self.0 | rhs.0;
+        Self(inner)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/reader/options.rs
+++ b/src/reader/options.rs
@@ -1,6 +1,6 @@
 /// [`DataReaderOptions`] is a type representing the various flags of
 /// [`DataReader`](super::DataReader) and options as the union of those flags.
-#[derive(Debug, PartialEq, Eq, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub struct DataReaderOptions(u32);
 
 impl DataReaderOptions {
@@ -8,6 +8,8 @@ impl DataReaderOptions {
     pub const ENABLE_READING_BODY: Self = Self(1 << 1);
     /// Flag to ignore the value of `data_size` header field.
     pub const IGNORE_DATA_SIZE_FIELD: Self = Self(1 << 2);
+    /// Flag to allow a trailing comma in the `format` header field.
+    pub const ALLOW_TRAILING_COMMA: Self = Self(1 << 3);
 
     /// Returns the union of `self` and a `flag`.
     pub fn union(&self, flag: Self) -> Self {

--- a/src/reader/options.rs
+++ b/src/reader/options.rs
@@ -13,6 +13,8 @@ impl DataReaderOptions {
     /// Flag to allow an empty string to be used for a field name when there are
     /// no other fields.
     pub const ALLOW_EMPTY_FIELD_NAME: Self = Self(1 << 4);
+    /// Flag to allow use of `<N>STR` instead of `<N>NSTR`.
+    pub const ALLOW_STR_INSTEAD_OF_NSTR: Self = Self(1 << 5);
 
     /// Returns the union of `self` and a `flag`.
     pub fn union(&self, flag: Self) -> Self {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -345,14 +345,15 @@ impl IndentLevel {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::Schema;
+    use crate::{ast::Schema, DataReaderOptions};
 
     macro_rules! test_schema_oneline_display {
         ($(($name:ident, $schema:expr),)*) => ($(
             #[test]
             fn $name() {
                 let input = $schema;
-                let schema = input.parse::<Schema>().unwrap();
+                let options = DataReaderOptions::default();
+                let schema = Schema::try_from((input.as_bytes(), options)).unwrap();
                 let output = format!("{}", SchemaOnelineDisplay(&schema.ast));
 
                 assert_eq!(output, input);
@@ -527,7 +528,8 @@ mod tests {
         ($(($name:ident, $schema:expr, $buf:expr, $expected:expr),)*) => ($(
             #[test]
             fn $name() {
-                let schema = $schema.parse::<Schema>().unwrap();
+                let options = crate::DataReaderOptions::default();
+                let schema = Schema::try_from(($schema.as_bytes(), options)).unwrap();
                 let buf = $buf;
                 let actual = format!("{}", JsonDisplay::new(&schema, &buf, JsonFormattingStyle::Minimal));
                 let expected = $expected
@@ -561,7 +563,8 @@ mod tests {
 
     #[test]
     fn json_serialization_with_pretty_printing_style() {
-        let schema = NESTED_DATA_SCHEMA.parse::<Schema>().unwrap();
+        let options = crate::DataReaderOptions::default();
+        let schema = Schema::try_from((NESTED_DATA_SCHEMA.as_bytes(), options)).unwrap();
         let actual = format!(
             "{}",
             JsonDisplay::new(&schema, NESTED_DATA_BUF, JsonFormattingStyle::Pretty)

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -345,7 +345,7 @@ impl IndentLevel {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ast::Schema, DataReaderOptions};
+    use crate::{ast::parse, DataReaderOptions};
 
     macro_rules! test_schema_oneline_display {
         ($(($name:ident, $schema:expr),)*) => ($(
@@ -353,7 +353,7 @@ mod tests {
             fn $name() {
                 let input = $schema;
                 let options = DataReaderOptions::default();
-                let schema = Schema::try_from((input.as_bytes(), options)).unwrap();
+                let schema = parse(input.as_bytes(), options).unwrap();
                 let output = format!("{}", SchemaOnelineDisplay(&schema.ast));
 
                 assert_eq!(output, input);
@@ -529,7 +529,7 @@ mod tests {
             #[test]
             fn $name() {
                 let options = crate::DataReaderOptions::default();
-                let schema = Schema::try_from(($schema.as_bytes(), options)).unwrap();
+                let schema = parse($schema.as_bytes(), options).unwrap();
                 let buf = $buf;
                 let actual = format!("{}", JsonDisplay::new(&schema, &buf, JsonFormattingStyle::Minimal));
                 let expected = $expected
@@ -564,7 +564,7 @@ mod tests {
     #[test]
     fn json_serialization_with_pretty_printing_style() {
         let options = crate::DataReaderOptions::default();
-        let schema = Schema::try_from((NESTED_DATA_SCHEMA.as_bytes(), options)).unwrap();
+        let schema = parse(NESTED_DATA_SCHEMA.as_bytes(), options).unwrap();
         let actual = format!(
             "{}",
             JsonDisplay::new(&schema, NESTED_DATA_BUF, JsonFormattingStyle::Pretty)

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -2,6 +2,7 @@ use std::ops::Deref;
 
 use drop_area::FileDropArea;
 use gloo_file::{futures::read_as_bytes, Blob};
+use rrr::DataReaderOptions;
 use yew::prelude::*;
 
 mod drop_area;
@@ -55,7 +56,10 @@ fn app() -> Html {
                     if let Ok(bytes) = result {
                         let mut reader = rrr::DataReader::new(
                             std::io::Cursor::new(&bytes),
-                            rrr::DataReaderOptions::ENABLE_READING_BODY,
+                            DataReaderOptions::ALLOW_TRAILING_COMMA
+                                | DataReaderOptions::ALLOW_EMPTY_FIELD_NAME
+                                | DataReaderOptions::ALLOW_STR_INSTEAD_OF_NSTR
+                                | DataReaderOptions::ENABLE_READING_BODY,
                         );
                         let triplet = reader.read();
                         file_content.set(triplet.ok())

--- a/web/src/tree.rs
+++ b/web/src/tree.rs
@@ -103,7 +103,7 @@ fn prettify_special_field_name(name: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use rrr::{DataReaderOptions, Schema};
+    use rrr::{parse, DataReaderOptions};
 
     use super::*;
 
@@ -113,7 +113,7 @@ mod tests {
             fn $name() {
                 let input = $input;
                 let options = DataReaderOptions::default();
-                let schema = Schema::try_from((input.as_bytes(), options)).unwrap();
+                let schema = parse(input.as_bytes(), options).unwrap();
                 let actual = create_schema_tree(&schema.ast).unwrap();
                 let expected = $expected;
 

--- a/web/src/tree.rs
+++ b/web/src/tree.rs
@@ -112,7 +112,9 @@ mod tests {
             #[test]
             fn $name() {
                 let input = $input;
-                let options = DataReaderOptions::default();
+                let options = DataReaderOptions::ALLOW_TRAILING_COMMA
+                    | DataReaderOptions::ALLOW_EMPTY_FIELD_NAME
+                    | DataReaderOptions::ALLOW_STR_INSTEAD_OF_NSTR;
                 let schema = parse(input.as_bytes(), options).unwrap();
                 let actual = create_schema_tree(&schema.ast).unwrap();
                 let expected = $expected;

--- a/web/src/tree.rs
+++ b/web/src/tree.rs
@@ -103,7 +103,7 @@ fn prettify_special_field_name(name: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use rrr::Schema;
+    use rrr::{DataReaderOptions, Schema};
 
     use super::*;
 
@@ -112,7 +112,8 @@ mod tests {
             #[test]
             fn $name() {
                 let input = $input;
-                let schema = input.parse::<Schema>().unwrap();
+                let options = DataReaderOptions::default();
+                let schema = Schema::try_from((input.as_bytes(), options)).unwrap();
                 let actual = create_schema_tree(&schema.ast).unwrap();
                 let expected = $expected;
 


### PR DESCRIPTION
This PR adds support for some format variants.

Some of the systems that generate data in the WNI RU format generate data in variant formats,
which are slightly different from the format specified in the specifications referenced in the development of this library.
This PR adds support for following 3 cases:

- Allow a trailing comma in the schema description
- Allow an empty field name in the schema description when it is the only field in the schema
- Allow use of `<N>STR` instead of `<N>NSTR` in the schema description

Each of these cases can be optionally enabled using flags.

All of these options are enabled in the CLI and the web demo app.